### PR TITLE
Add Support to Laravel 11

### DIFF
--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -20,16 +20,7 @@ jobs:
         php-version: 8.3
         coverage: none
 
-    - name: Cache Composer packages
-      id: composer-cache
-      uses: actions/cache@v3
-      with:
-        path: vendor
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: ${{ runner.os }}-composer-
-
     - name: Install dependencies
-      if: steps.composer-cache.outputs.cache-hit != 'true'
       run: |
         composer install
         composer dump

--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -1,4 +1,4 @@
-name: analyze
+name: PHPStan
 
 on:
   push:
@@ -8,7 +8,6 @@ on:
 
 jobs:
   phpstan:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -19,6 +18,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: 8.3
+        coverage: none
 
     - name: Cache Composer packages
       id: composer-cache

--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install dependencies
       if: steps.composer-cache.outputs.cache-hit != 'true'
       run: |
-        composer install
+        composer install --no-interaction --no-progress
         composer dump
 
     - name: Run analyse phpstan

--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -1,4 +1,4 @@
-name: PHPStan
+name: Analyse
 
 on:
   push:
@@ -18,9 +18,18 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: 8.3
-        coverage: none
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v4
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-8.3-${{ hashFiles('**/composer.json') }}
+        restore-keys: |
+          ${{ runner.os }}-php-8.3
 
     - name: Install dependencies
+      if: steps.composer-cache.outputs.cache-hit != 'true'
       run: |
         composer install
         composer dump

--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -1,4 +1,4 @@
-name: analyse
+name: analyze
 
 on:
   push:
@@ -12,27 +12,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.1
+        php-version: 8.3
 
-    - name: Get Composer Cache Directory
+    - name: Cache Composer packages
       id: composer-cache
-      run: |
-        echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-    - uses: actions/cache@v3
+      uses: actions/cache@v3
       with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ matrix.php-versions }}-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-8.1
+        path: vendor
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: ${{ runner.os }}-composer-
 
     - name: Install dependencies
-      if: steps.cache-descom-laravel-auth.outputs.cache-hit != 'true'
+      if: steps.composer-cache.outputs.cache-hit != 'true'
       run: |
         composer install
         composer dump

--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -26,7 +26,7 @@ jobs:
         path: vendor
         key: ${{ runner.os }}-php-8.3-${{ hashFiles('**/composer.json') }}
         restore-keys: |
-          ${{ runner.os }}-php-8.3
+          ${{ runner.os }}-php-8.3-
 
     - name: Install dependencies
       if: steps.composer-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/style-fix.yml
+++ b/.github/workflows/style-fix.yml
@@ -24,12 +24,12 @@ jobs:
           path: vendor
           key: ${{ runner.os }}-php-8.3-${{ hashFiles('**/composer.json') }}
           restore-keys: |
-            ${{ runner.os }}-php-8.3
+            ${{ runner.os }}-php-8.3-
 
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: |
-          composer install
+          composer install --no-interaction --no-progress
           composer dump
 
       - name: Fix styles

--- a/.github/workflows/style-fix.yml
+++ b/.github/workflows/style-fix.yml
@@ -18,16 +18,7 @@ jobs:
         php-version: 8.3
         coverage: none
 
-    - name: Cache Composer packages
-      id: composer-cache
-      uses: actions/cache@v3
-      with:
-        path: vendor
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: ${{ runner.os }}-composer-
-
     - name: Install dependencies
-      if: steps.composer-cache.outputs.cache-hit != 'true'
       run: |
         composer install
         composer dump

--- a/.github/workflows/style-fix.yml
+++ b/.github/workflows/style-fix.yml
@@ -5,7 +5,7 @@ on:
     branches: [master]
 
 jobs:
-  style:
+  style-fix:
     runs-on: ubuntu-latest
 
     steps:
@@ -16,6 +16,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: 8.3
+        coverage: none
 
     - name: Cache Composer packages
       id: composer-cache

--- a/.github/workflows/style-fix.yml
+++ b/.github/workflows/style-fix.yml
@@ -9,24 +9,33 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: 8.3
-        coverage: none
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
 
-    - name: Install dependencies
-      run: |
-        composer install
-        composer dump
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-8.3-${{ hashFiles('**/composer.json') }}
+          restore-keys: |
+            ${{ runner.os }}-php-8.3
 
-    - name: Fix styles
-      run: vendor/bin/php-cs-fixer fix
+      - name: Install dependencies
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: |
+          composer install
+          composer dump
 
-    - uses: EndBug/add-and-commit@v9
+      - name: Fix styles
+        run: vendor/bin/php-cs-fixer fix
 
-    - name: Run style
-      run: vendor/bin/php-cs-fixer fix --dry-run --diff --format junit
+      - name: Run style
+        run: vendor/bin/php-cs-fixer fix --dry-run --diff --format junit
+
+      - uses: EndBug/add-and-commit@v9

--- a/.github/workflows/style-fix.yml
+++ b/.github/workflows/style-fix.yml
@@ -1,12 +1,13 @@
-name: style-fix
+name: Style fix
 
 on:
   push:
     branches: [master]
-
+  pull_request:
+    branches: [master]
+    
 jobs:
-  style-fix:
-
+  style:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/style-fix.yml
+++ b/.github/workflows/style-fix.yml
@@ -5,7 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
-    
+
 jobs:
   style:
     runs-on: ubuntu-latest
@@ -13,6 +13,11 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: 8.3
 
     - name: Cache Composer packages
       id: composer-cache

--- a/.github/workflows/style-fix.yml
+++ b/.github/workflows/style-fix.yml
@@ -5,32 +5,24 @@ on:
     branches: [master]
 
 jobs:
-  style:
+  style-fix:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v4
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: 8.1
-
-    - name: Get Composer Cache Directory
+    - name: Cache Composer packages
       id: composer-cache
-      run: |
-        echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-    - uses: actions/cache@v3
+      uses: actions/cache@v3
       with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ matrix.php-versions }}-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-8.1
+        path: vendor
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: ${{ runner.os }}-composer-
 
     - name: Install dependencies
-      if: steps.cache-descom-laravel-auth.outputs.cache-hit != 'true'
+      if: steps.composer-cache.outputs.cache-hit != 'true'
       run: |
         composer install
         composer dump

--- a/.github/workflows/style-fix.yml
+++ b/.github/workflows/style-fix.yml
@@ -3,8 +3,6 @@ name: Style fix
 on:
   push:
     branches: [master]
-  pull_request:
-    branches: [master]
 
 jobs:
   style:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,8 +33,7 @@ jobs:
         with:
           path: vendor
           key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-${{ matrix.php }}
+          restore-keys: ${{ runner.os }}-php-${{ matrix.php }}
 
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: |
-          composer install
+          composer install --no-interaction --no-progress
           composer dump
 
       - name: Run test phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.0, 8.1, 8.2, 8.3]
+        php: [8.1, 8.2, 8.3]
 
     steps:
       - uses: actions/checkout@v4
@@ -22,7 +22,6 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, bcmath, intl, exif
-          coverage: xdebug
 
       - name: Validate composer.json and composer.lock
         run: composer validate
@@ -42,4 +41,4 @@ jobs:
           composer dump
 
       - name: Run test phpunit
-        run: vendor/bin/phpunit
+        run: vendor/bin/phpunit --stop-on-error --stop-on-failure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, bcmath, intl, exif
 
-      - name: Validate composer.json and composer.lock
+      - name: Validate composer.json
         run: composer validate
 
       - name: Cache Composer packages

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 jobs:
-  tests:
+  test:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, bcmath, intl, exif
 
       - name: Validate composer.json
         run: composer validate

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: true
       matrix:
         php: [8.1, 8.2, 8.3]
 
@@ -23,12 +24,21 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, bcmath, intl, exif
-          coverage: none
 
       - name: Validate composer.json
         run: composer validate
 
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-${{ matrix.php }}-
+
       - name: Install dependencies
+        if: steps.composer-cache.outputs.cache-hit != 'true'
         run: |
           composer install
           composer dump

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,4 +44,4 @@ jobs:
           composer dump
 
       - name: Run test phpunit
-        run: composer test
+        run: vendor/bin/phpunit --stop-on-error --stop-on-failure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,4 +44,4 @@ jobs:
           composer dump
 
       - name: Run test phpunit
-        run: vendor/bin/phpunit --stop-on-error --stop-on-failure
+        run: composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,17 @@ jobs:
       - name: Validate composer.json and composer.lock
         run: composer validate
 
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-${{ matrix.php }}
+
       - name: Install dependencies
+        if: steps.composer-cache.outputs.cache-hit != 'true'
         run: |
           composer install
           composer dump

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,8 @@ on:
     branches: [master]
 
 jobs:
-  test:
+  phpunit:
+
     runs-on: ubuntu-latest
 
     strategy:
@@ -15,7 +16,8 @@ jobs:
         php: [8.1, 8.2, 8.3]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: tests
+name: Tests
 
 on:
   push:
@@ -8,7 +8,6 @@ on:
 
 jobs:
   phpunit:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -24,6 +23,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, bcmath, intl, exif
+          coverage: none
 
       - name: Validate composer.json
         run: composer validate

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,16 +28,7 @@ jobs:
       - name: Validate composer.json
         run: composer validate
 
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v3
-        with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-php-${{ matrix.php }}
-
       - name: Install dependencies
-        if: steps.composer-cache.outputs.cache-hit != 'true'
         run: |
           composer install
           composer dump

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,32 +7,30 @@ on:
     branches: [master]
 
 jobs:
-  phpunit:
-
+  tests:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        php-versions: ['8.3', '8.2', '8.1', '8.0']
+        php: [8.0, 8.1, 8.2, 8.3]
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php-versions }}
-        extensions: dom, curl, libxml, mbstring, zip, pcntl, bcmath, intl, exif
-        coverage: xdebug
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, bcmath, intl, exif
+          coverage: xdebug
 
+      - name: Validate composer.json and composer.lock
+        run: composer validate
 
-    - name: Validate composer.json and composer.lock
-      run: composer validate
+      - name: Install dependencies
+        run: |
+          composer install
+          composer dump
 
-    - name: Install dependencies
-      run: |
-        composer install
-        composer dump
-
-    - name: Run test phpunit
-      run: vendor/bin/phpunit
+      - name: Run test phpunit
+        run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "guzzlehttp/guzzle": "^7.4",
         "league/omnipay": "^3.2",
         "omnipay/common": "^3.2",
-        "illuminate/contracts": "^9.25|^10.0"
+        "illuminate/contracts": "^9.25|^10.0|^11.0"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1",

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
     "require-dev": {
         "guzzlehttp/psr7": "^1",
         "omnipay/tests": "^4.1",
-        "phpunit/phpunit": "^9.5",
-        "orchestra/testbench": "^7.0|^8.0",
+        "phpunit/phpunit": "^9.5|^10.0|^10.5",
+        "orchestra/testbench": "^7.0|^8.0|^9.0",
         "friendsofphp/php-cs-fixer": "^3.10",
         "phpstan/phpstan": "^1.8",
         "nunomaduro/larastan": "^2.1"

--- a/tests/PurchaseTest.php
+++ b/tests/PurchaseTest.php
@@ -20,9 +20,6 @@ class PurchaseTest extends TestCase
 
     public function testPurchaseRequest()
     {
-        if (!true) {
-            // (1) Replace the following line:
-        }
         $request = $this->gateway->purchase([
             'amount' => '12.00',
             'description' => 'Test purchase',

--- a/tests/PurchaseTest.php
+++ b/tests/PurchaseTest.php
@@ -20,6 +20,9 @@ class PurchaseTest extends TestCase
 
     public function testPurchaseRequest()
     {
+        if (!true) {
+            // (1) Replace the following line:
+        }
         $request = $this->gateway->purchase([
             'amount' => '12.00',
             'description' => 'Test purchase',
@@ -49,10 +52,10 @@ class PurchaseTest extends TestCase
         $responseHtml = $this->gateway
             ->purchase(
                 [
-                'amount' => '12.00',
-                'description' => 'Test purchase',
-                'transactionId' => 1,
-            ]
+                    'amount' => '12.00',
+                    'description' => 'Test purchase',
+                    'transactionId' => 1,
+                ]
             )->send()
             ->getRedirectResponse()
             ->getContent();


### PR DESCRIPTION
## Revisar

El paquete no instala Laravel, ¿es necesario hacer una matriz de versiones de laravel en el test.yml? (Ver otro PR hecho por César)

## Comentarios

Ha habido que añadir la version 11 de "illuminate/contracts" al composer para que fuera compatible con Laravel11.
Revisar si es necesario el paquete "illuminate/contracts", creo que se puede eliminar y no es necesario para este proyecto.